### PR TITLE
python 3.9 in poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.6"
+    "Programming Language :: Python :: 3.9"
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.9"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
<!-- Thank you for contributing to Zeta!

Bumped python version to 3.9

This will allow Ruff to install and run with poetry.
