### PR TITLE
bare labeler config file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# this is a config file for the github action labeler
+
+# Add 'label1' to any changes within 'example' folder or any subfolders
+example_change:
+- example/**
+
+# Add 'label2' to any file changes within 'example2' folder
+example2_change: example2/*
+
+# Add label3 to any change to .txt files within the entire repository. Quotation marks are required for the leading asterisk
+text_files:
+- '**/*.txt'

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     name: 👋 Welcome
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/first-interaction@v1.1.1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Zeta!
The lableler workflow was failing because it didn't have a config file.
This patch adds an bare bones config file.

I'm not sure if you want to keep using the labeler workflow, but if you do, this will at least avoid some errors.
